### PR TITLE
ci: fix codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,15 @@
 flags:
   backend:
     paths:
-      - app/backend/
+      - packages/backend/
   frontend:
     paths:
-      - app/frontend/
+      - packages/frontend/
   shared:
     paths:
-      - app/shared/
+      - packages/shared/
+
+coverage:
+  status:
+    project: off
+    patch: off


### PR DESCRIPTION
don’t report failures for now, until playwright/storybook coverage is correctly integrated